### PR TITLE
Path Fixes and 404 fix

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -79,6 +79,7 @@ func elementsHandler(config httpConfig, w http.ResponseWriter, r *http.Request) 
 	path = strings.Replace(path, "/", ".", -1)
 	debug.Printf("Element path requested: %s", path)
 
+	config.EConfig.Path = path
 	elements := e.Elements{
 		Config: config.EConfig,
 	}

--- a/lib/elements/elements.go
+++ b/lib/elements/elements.go
@@ -91,11 +91,15 @@ func (e *Elements) ElementsAtPath() (interface{}, error) {
 			if err != nil {
 				if _, ok := data.(map[string]interface{}); ok {
 					value = data.(map[string]interface{})[p]
+				} else {
+					value = nil
 				}
 			} else {
 				if _, ok := data.([]interface{}); ok {
-					if len(data.([]interface{})) >= i {
+					if len(data.([]interface{})) > i {
 						value = data.([]interface{})[i]
+					} else {
+						value = nil
 					}
 				}
 			}

--- a/lib/output/output.go
+++ b/lib/output/output.go
@@ -15,6 +15,10 @@ type Output struct {
 }
 
 func (o *Output) Generate(elements interface{}) (string, error) {
+	if elements == nil {
+		return "", nil
+	}
+
 	switch o.Config.Format {
 	case "json":
 		return o.JSONOutput(elements)


### PR DESCRIPTION
This commit fixes two bugs related to path parsing:

1. A path requested via http was not being recognized.
2. Paths could hit an out of bound error.

This commit also fixes a bug where a 404 was not being
returned correctly.

Fixes #4 