### PR TITLE
Support format overrides via query parameters

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -79,12 +79,10 @@ func elementsHandler(config httpConfig, w http.ResponseWriter, r *http.Request) 
 	path = strings.Replace(path, "/", ".", -1)
 	debug.Printf("Element path requested: %s", path)
 
-  format := r.FormValue("format")
-	if format == "" {
-		format = config.OConfig.Format
+	if v := r.FormValue("format"); v != "" {
+		debug.Printf("Format override requested: %s", v)
+		config.OConfig.Format = v
 	}
-
-	config.OConfig.Format = format
 
 	output := o.Output{
 		Config: config.OConfig,
@@ -100,13 +98,14 @@ func elementsHandler(config httpConfig, w http.ResponseWriter, r *http.Request) 
 		return &httpError{err, "Error collecting elements", 500}
 	}
 
-	formattedOutput, outputErr := output.Generate(collectedElements)
-
 	title := fmt.Sprintf("Elements %s", version)
 	w.Header().Set("Server", title)
+
+	formattedOutput, outputErr := output.Generate(collectedElements)
+
 	if outputErr != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("Invalid format requested"))
+		w.Write([]byte(outputErr.Error()))
 	} else if formattedOutput == "" {
 		w.WriteHeader(http.StatusNotFound)
 		w.Write([]byte("Element path not found"))

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -79,6 +79,21 @@ func elementsHandler(config httpConfig, w http.ResponseWriter, r *http.Request) 
 	path = strings.Replace(path, "/", ".", -1)
 	debug.Printf("Element path requested: %s", path)
 
+	format := r.FormValue("format")
+	if format != "" {
+		formatSupported := false
+		for _, match := range []string{"json", "shell"} {
+			if match == format {
+				formatSupported = true
+				debug.Printf("Output format requested: %s", format)
+				config.OConfig.Format = format
+			}
+		}
+		if !formatSupported {
+			debug.Printf("Unsupported output format requested: %s", format)
+		}
+	}
+
 	config.EConfig.Path = path
 	elements := e.Elements{
 		Config: config.EConfig,


### PR DESCRIPTION
Allows HTTP clients to override default output formatting via query
parameters, like so:

curl localhost:8888/elements/path?format=shell

Unsupported format parameters will return the default output format.

I'm new to golang, so this is likely unidiomatic. It strikes me that the list of supported output formats should be retrievable via the `config.OConfig` struct, rather than hard-coded here, but that is a bit beyond my current ability with Go.

Advances #7.