### PR TITLE
Automatic cloud detection and elements retrieval for AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Elements
 
-Elements retrieves information about a system such as CPU/Processors, disks, memory, and network interfaces. It is meant to be used to poll a system about its static attributes.
+Elements retrieves information about a system such as CPU/Processors, disks, memory, network interfaces, and cloud metadata. It is meant to be used to poll a system about it's static attributes.
 
 This tool is similar to Facter, Ohai, Ansible facts, etc.
 

--- a/lib/elements/aws.go
+++ b/lib/elements/aws.go
@@ -38,7 +38,10 @@ func crawlData(url string) map[string]interface{} {
 
 		switch {
 		default:
-			data[key] = getData(url + line)[0]
+			d := getData(url + line)
+			if len(d) > 0 {
+				data[key] = d[0]
+			}
 		case line == "dynamic":
 			break
 		case line == "meta-data":

--- a/lib/elements/aws.go
+++ b/lib/elements/aws.go
@@ -1,0 +1,88 @@
+package elements
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+func getData(url string) (data []string) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return make([]string, 0)
+	}
+
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		data = append(data, strings.TrimRight(scanner.Text(), "\n"))
+		if err != nil {
+			break
+		}
+	}
+	return
+}
+
+func crawlData(url string) map[string]interface{} {
+	data := make(map[string]interface{})
+	urlData := getData(url)
+
+	var key string
+	for _, line := range urlData {
+
+		// replace hyphens with underscores for JSON keys
+		key = strings.Replace(line, "-", "_", -1)
+
+		switch {
+		default:
+			data[key] = getData(url + line)[0]
+		case line == "dynamic":
+			break
+		case line == "meta-data":
+			data[key] = crawlData(url + line + "/")
+		case line == "user-data":
+			data[key] = strings.Join(getData(url+line+"/"), "")
+		case strings.HasSuffix(line, "/"):
+			data[key[:len(line)-1]] = crawlData(url + line)
+		case strings.HasSuffix(url, "public-keys/"):
+			keyId := strings.SplitN(line, "=", 2)[0]
+			data[key] = crawlData(url + keyId + "/")
+		}
+	}
+	return data
+}
+
+func jsonData(url string) ([]byte, error) {
+	data, err := json.MarshalIndent(crawlData(url), "", "    ")
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (e *Elements) GetAWSElements() (map[string]interface{}, error) {
+	url := "http://169.254.169.254/latest/"
+
+	data, err := jsonData(url)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to marshal data from ec2 crawl: %s", err)
+	}
+
+	ec2Elements := make(map[string]interface{})
+	err = json.Unmarshal(data, &ec2Elements)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to unmarshal data from ec2 JSON: %s", err)
+	}
+
+	return ec2Elements, nil
+}
+
+/*
+Attribution: much of the code in this file was lifted from the ec2_metadata_dump
+project: https://github.com/thbishop/ec2_metadata_dump, which is:
+
+Copyright (c) 2013 Thomas Bishop
+*/

--- a/lib/elements/cloud.go
+++ b/lib/elements/cloud.go
@@ -1,0 +1,24 @@
+package elements
+
+import (
+	"fmt"
+)
+
+func (e *Elements) GetCloudElements(provider string) (map[string]interface{}, error) {
+
+	var cloudElements map[string]interface{}
+	var err error
+
+	switch provider {
+	case "aws":
+		cloudElements, err = e.GetAWSElements()
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("Cloud provider '%s' is not supported.", provider)
+	}
+
+	cloudElements["provider"] = provider
+	return cloudElements, nil
+}

--- a/lib/elements/elements.go
+++ b/lib/elements/elements.go
@@ -75,11 +75,9 @@ func (e *Elements) Get() (interface{}, error) {
 		e.Add("external", externalElements)
 
 		if cloud != "" {
-			cloudElements, err := e.GetCloudElements(cloud)
-			if err != nil {
-				return nil, err
+			if cloudElements, err := e.GetCloudElements(cloud); err == nil {
+				e.Add("cloud", cloudElements)
 			}
-			e.Add("cloud", cloudElements)
 		}
 	}
 

--- a/lib/elements/elements.go
+++ b/lib/elements/elements.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/erichs/cloudsysfs"
 )
 
 type Config struct {
@@ -34,6 +36,9 @@ func (e *Elements) Add(key string, value interface{}) {
 func (e *Elements) Get() (interface{}, error) {
 	systemPathRE := regexp.MustCompile("^system")
 	externalPathRE := regexp.MustCompile("^external")
+	cloudPathRE := regexp.MustCompile("^cloud")
+
+	cloud := cloudsysfs.Detect()
 
 	switch {
 	case systemPathRE.MatchString(e.Config.Path):
@@ -48,18 +53,34 @@ func (e *Elements) Get() (interface{}, error) {
 			return nil, err
 		}
 		e.Add("external", externalElements)
+	case cloudPathRE.MatchString(e.Config.Path):
+		if cloud != "" {
+			cloudElements, err := e.GetCloudElements(cloud)
+			if err != nil {
+				return nil, err
+			}
+			e.Add("cloud", cloudElements)
+		}
 	default:
 		elements, err := e.GetSystemElements()
 		if err != nil {
 			return nil, err
 		}
+		e.Add("system", elements)
 
 		externalElements, err := e.GetExternalElements()
 		if err != nil {
 			return nil, err
 		}
-		e.Add("system", elements)
 		e.Add("external", externalElements)
+
+		if cloud != "" {
+			cloudElements, err := e.GetCloudElements(cloud)
+			if err != nil {
+				return nil, err
+			}
+			e.Add("cloud", cloudElements)
+		}
 	}
 
 	return e.ElementsAtPath()

--- a/vendor/github.com/erichs/cloudsysfs/LICENSE
+++ b/vendor/github.com/erichs/cloudsysfs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Erich Smith
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/erichs/cloudsysfs/README.md
+++ b/vendor/github.com/erichs/cloudsysfs/README.md
@@ -1,0 +1,80 @@
+# cloudsysfs
+Detect Cloud Provider from DMI data on the local sysfs (/sys) filesystem
+
+## Usage
+
+```go
+package main
+
+import (
+  "fmt"
+
+  "github.com/erichs/cloudsysfs"
+)
+
+func main() {
+  switch cloudsysfs.Detect() {
+  case "aws":
+    fmt.Println("Amazon Web Services")
+  case "azure":
+    fmt.Println("Microsofte Azure")
+  case "digitalocean":
+    fmt.Println("Digital Ocean")
+  case "gce":
+    fmt.Println("Google Compute Engine")
+  case "openstack":
+    fmt.Println("OpenStack")
+  default:
+    fmt.Println("No cloud detected")
+  }
+}
+
+``` 
+
+## Motivation
+
+Inspired by [cloudid](https://github.com/appscode/cloudid), I wanted a simple and fast mechanism for determining if the local environment is a cloud I want to support. [cloudid](https://github.com/appscode/cloudid) is great, but takes the (admittedly more robust) approach of fingerprinting metadata signatures from APIPA HTTP API endpoints (`http://169.254.x.x/latest/metadata` and friends). 
+
+This library takes the approach of attempting to read from the local [sysfs filesystem](https://en.wikipedia.org/wiki/Sysfs), looking for unambiguous vendor or product files that identify the cloud provider. The /sys filesystem is provided by the Linux kernel, so only Linux is currently supported.
+
+## Supported Operating Systems
+
+Linux
+
+## Supported Cloud Providers
+| provider_id | Name                  
+|-------------|-----------
+|aws          | Amazon Web Services  
+|azure        | Microsoft Azure      
+|digitalocean | DigitalOcean          
+|gce          | Google Compute Engine
+|openstack    | OpenStack
+
+## Example
+
+```      
+package main
+
+import (
+  "fmt"
+
+  "github.com/erichs/cloudsysfs"
+)
+
+func main() {
+  switch cloudsysfs.Detect() {
+  case "aws":
+    fmt.Println("Amazon Web Services")
+  case "azure":
+    fmt.Println("Microsofte Azure")
+  case "digitalocean":
+    fmt.Println("Digital Ocean")
+  case "gce":
+    fmt.Println("Google Compute Engine")
+  case "openstack":
+    fmt.Println("OpenStack")
+  default:
+    fmt.Println("No cloud detected")
+  }
+}
+```

--- a/vendor/github.com/erichs/cloudsysfs/detect.go
+++ b/vendor/github.com/erichs/cloudsysfs/detect.go
@@ -9,6 +9,7 @@ var Providers = [...]func(chan<- string){
 	providers.Azure,
 	providers.DigitalOcean,
 	providers.GCE,
+	providers.OpenStack,
 }
 
 func Detect() string {

--- a/vendor/github.com/erichs/cloudsysfs/detect.go
+++ b/vendor/github.com/erichs/cloudsysfs/detect.go
@@ -1,0 +1,29 @@
+package cloudsysfs
+
+import (
+	"github.com/erichs/cloudsysfs/providers"
+)
+
+var Providers = [...]func(chan<- string){
+	providers.AWS,
+	providers.Azure,
+	providers.DigitalOcean,
+	providers.GCE,
+}
+
+func Detect() string {
+	sysfscheck := make(chan string)
+	for _, cloud := range Providers {
+		go cloud(sysfscheck)
+	}
+
+	provider := ""
+	for i := 0; i < len(Providers); i++ {
+		v := <-sysfscheck
+		if v != "" {
+			provider = v
+		}
+	}
+
+	return provider
+}

--- a/vendor/github.com/erichs/cloudsysfs/providers/aws.go
+++ b/vendor/github.com/erichs/cloudsysfs/providers/aws.go
@@ -1,0 +1,17 @@
+package providers
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+func AWS(sysfscheck chan<- string) {
+	data, err := ioutil.ReadFile("/sys/class/dmi/id/product_version")
+	if err != nil {
+		sysfscheck <- ""
+	}
+	if strings.Contains(string(data), "amazon") {
+		sysfscheck <- "aws"
+	}
+	sysfscheck <- ""
+}

--- a/vendor/github.com/erichs/cloudsysfs/providers/azure.go
+++ b/vendor/github.com/erichs/cloudsysfs/providers/azure.go
@@ -1,0 +1,17 @@
+package providers
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+func Azure(sysfscheck chan<- string) {
+	data, err := ioutil.ReadFile("/sys/class/dmi/id/sys_vendor")
+	if err != nil {
+		sysfscheck <- ""
+	}
+	if strings.Contains(string(data), "Microsoft Corporation") {
+		sysfscheck <- "azure"
+	}
+	sysfscheck <- ""
+}

--- a/vendor/github.com/erichs/cloudsysfs/providers/digitalocean.go
+++ b/vendor/github.com/erichs/cloudsysfs/providers/digitalocean.go
@@ -1,0 +1,17 @@
+package providers
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+func DigitalOcean(sysfscheck chan<- string) {
+	data, err := ioutil.ReadFile("/sys/class/dmi/id/sys_vendor")
+	if err != nil {
+		sysfscheck <- ""
+	}
+	if strings.Contains(string(data), "DigitalOcean") {
+		sysfscheck <- "digitalocean"
+	}
+	sysfscheck <- ""
+}

--- a/vendor/github.com/erichs/cloudsysfs/providers/gce.go
+++ b/vendor/github.com/erichs/cloudsysfs/providers/gce.go
@@ -1,0 +1,17 @@
+package providers
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+func GCE(sysfscheck chan<- string) {
+	data, err := ioutil.ReadFile("/sys/class/dmi/id/product_name")
+	if err != nil {
+		sysfscheck <- ""
+	}
+	if strings.Contains(string(data), "Google") {
+		sysfscheck <- "gce"
+	}
+	sysfscheck <- ""
+}

--- a/vendor/github.com/erichs/cloudsysfs/providers/openstack.go
+++ b/vendor/github.com/erichs/cloudsysfs/providers/openstack.go
@@ -1,0 +1,17 @@
+package providers
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+func OpenStack(sysfscheck chan<- string) {
+	data, err := ioutil.ReadFile("/sys/class/dmi/id/sys_vendor")
+	if err != nil {
+		sysfscheck <- ""
+	}
+	if strings.Contains(string(data), "OpenStack Foundation") {
+		sysfscheck <- "openstack"
+	}
+	sysfscheck <- ""
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,6 +9,18 @@
 			"revisionTime": "2016-08-11T21:45:55Z"
 		},
 		{
+			"checksumSHA1": "FNWcGKzq/1wnofjl3uh26QyBFh4=",
+			"path": "github.com/erichs/cloudsysfs",
+			"revision": "79d2e0513d5ae50055544dc25f0342b1dfa2be03",
+			"revisionTime": "2017-04-04T02:09:12Z"
+		},
+		{
+			"checksumSHA1": "kpCImZXUdKsVllCq1UtjoWAXjoc=",
+			"path": "github.com/erichs/cloudsysfs/providers",
+			"revision": "79d2e0513d5ae50055544dc25f0342b1dfa2be03",
+			"revisionTime": "2017-04-04T02:09:12Z"
+		},
+		{
 			"checksumSHA1": "wDZdTaY9JiqqqnF4c3pHP71nWmk=",
 			"path": "github.com/go-ole/go-ole",
 			"revision": "5e9c030faf78847db7aa77e3661b9cc449de29b7",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,16 +9,16 @@
 			"revisionTime": "2016-08-11T21:45:55Z"
 		},
 		{
-			"checksumSHA1": "FNWcGKzq/1wnofjl3uh26QyBFh4=",
+			"checksumSHA1": "LzIZNIPN2ojZm0sk5W6iEQbB6qg=",
 			"path": "github.com/erichs/cloudsysfs",
-			"revision": "79d2e0513d5ae50055544dc25f0342b1dfa2be03",
-			"revisionTime": "2017-04-04T02:09:12Z"
+			"revision": "ac460038d889fda70d312f5696d80ada84f49a8c",
+			"revisionTime": "2017-04-05T02:49:51Z"
 		},
 		{
 			"checksumSHA1": "kpCImZXUdKsVllCq1UtjoWAXjoc=",
 			"path": "github.com/erichs/cloudsysfs/providers",
-			"revision": "79d2e0513d5ae50055544dc25f0342b1dfa2be03",
-			"revisionTime": "2017-04-04T02:09:12Z"
+			"revision": "ac460038d889fda70d312f5696d80ada84f49a8c",
+			"revisionTime": "2017-04-05T02:49:51Z"
 		},
 		{
 			"checksumSHA1": "wDZdTaY9JiqqqnF4c3pHP71nWmk=",


### PR DESCRIPTION
EC2 instances provide a unique id beginning with the string "ec2" at
/sys/hypervisor/uuid. The presence of this file, and the first three
bytes equalling "ec2" is a pretty fast and reliable method of AWS
detection at runtime.

If we're an EC2 instance, assume the http://169.254.169.254/latest
endpoint is available (also a pretty reliable bet). Crawl this
recursively for meta and user data, populating the "ec2" top-level
element path.