### PR TITLE
Retrieve DigitalOcean and OpenStack metadata

### DIFF
--- a/lib/elements/cloud.go
+++ b/lib/elements/cloud.go
@@ -1,15 +1,21 @@
 package elements
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 )
 
 func (e *Elements) GetCloudElements(provider string) (map[string]interface{}, error) {
-
 	var cloudElements map[string]interface{}
 	var err error
 
 	switch provider {
+	case "openstack":
+		cloudElements, err = e.GetOpenStackElements()
+		if err != nil {
+			return nil, err
+		}
 	case "aws":
 		cloudElements, err = e.GetAWSElements()
 		if err != nil {
@@ -21,4 +27,21 @@ func (e *Elements) GetCloudElements(provider string) (map[string]interface{}, er
 
 	cloudElements["provider"] = provider
 	return cloudElements, nil
+}
+
+func (e *Elements) GetElementsFromJsonUrl(url string) (map[string]interface{}, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("Error retrieving metadata from '%s': %s", url, err)
+	}
+	defer resp.Body.Close()
+
+	jsonDecoder := json.NewDecoder(resp.Body)
+
+	osElements := make(map[string]interface{})
+	if err := jsonDecoder.Decode(&osElements); err != nil {
+		return nil, fmt.Errorf("Error processing metadata JSON: %s", err)
+	}
+
+	return osElements, nil
 }

--- a/lib/elements/cloud.go
+++ b/lib/elements/cloud.go
@@ -11,13 +11,18 @@ func (e *Elements) GetCloudElements(provider string) (map[string]interface{}, er
 	var err error
 
 	switch provider {
-	case "openstack":
-		cloudElements, err = e.GetOpenStackElements()
+	case "aws":
+		cloudElements, err = e.GetAWSElements()
 		if err != nil {
 			return nil, err
 		}
-	case "aws":
-		cloudElements, err = e.GetAWSElements()
+	case "digitalocean":
+		cloudElements, err = e.GetDigitalOceanElements()
+		if err != nil {
+			return nil, err
+		}
+	case "openstack":
+		cloudElements, err = e.GetOpenStackElements()
 		if err != nil {
 			return nil, err
 		}

--- a/lib/elements/digitalocean.go
+++ b/lib/elements/digitalocean.go
@@ -1,0 +1,5 @@
+package elements
+
+func (e *Elements) GetDigitalOceanElements() (map[string]interface{}, error) {
+	return e.GetElementsFromJsonUrl("http://169.254.169.254/metadata/v1.json")
+}

--- a/lib/elements/openstack.go
+++ b/lib/elements/openstack.go
@@ -1,0 +1,5 @@
+package elements
+
+func (e *Elements) GetOpenStackElements() (map[string]interface{}, error) {
+	return e.GetElementsFromJsonUrl("http://169.254.169.254/openstack/2013-10-17/meta_data.json")
+}

--- a/lib/elements/openstack.go
+++ b/lib/elements/openstack.go
@@ -1,5 +1,5 @@
 package elements
 
 func (e *Elements) GetOpenStackElements() (map[string]interface{}, error) {
-	return e.GetElementsFromJsonUrl("http://169.254.169.254/openstack/2013-10-17/meta_data.json")
+	return e.GetElementsFromJsonUrl("http://169.254.169.254/openstack/latest/meta_data.json")
 }


### PR DESCRIPTION
The recursive crawling strategy was too slow on the OpenStack instance I used. DigitalOcean and OpenStack both support a direct JSON url, the direct decoding of which was much faster.

