### PR TITLE
Escape double-quote chars in shell output values

### DIFF
--- a/lib/output/output.go
+++ b/lib/output/output.go
@@ -84,11 +84,21 @@ func parseElementsForShell(label string, elements interface{}, parsed map[string
 			_, e, parsed = parseElementsForShell(l, subElements, parsed)
 		}
 	default:
-		parsed[label] = fmt.Sprintf("%v", elements)
+		parsed[label] = fmt.Sprintf("%v", sanitizeValueForShell(elements))
 		return label, nil, parsed
 	}
 
 	return label, e, parsed
+}
+
+func sanitizeValueForShell(val interface{}) interface{} {
+	switch val.(type) {
+	case string:
+		// escape double quotes in shell string values
+		return strings.Replace(val.(string), "\"", "\\\"", -1)
+	default:
+		return val
+	}
 }
 
 func sanitizeKeyForShell(key string) string {


### PR DESCRIPTION
Doing: "eval $(elements get -f shell)" can result in errors if
element values themselves contain double quotes. This can occur, for
example in cloud User data.